### PR TITLE
Switch unstaking pagination key to delegate

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -38,7 +38,7 @@ const postgresQuery = (db: pkg.PoolClient, text: string, params: string[]) =>
  *
  * @param db Postgres DB client
  * @param limit The maximum number of results in a single page
- * @param prevId The id of the last retrieved unstake record.
+ * @param prevDelegate The delegate of the last retrieved unstake record.
  * @param prevTimestamp The timestamp of the last retrieved unstake record.
  * @param controller An optional controller for the unstake records
  * @returns An error code and error message if the parameters are invalid.
@@ -47,7 +47,7 @@ const postgresQuery = (db: pkg.PoolClient, text: string, params: string[]) =>
 export const getPaginatedUnstakings = async (
   db: pkg.PoolClient,
   limit: string | null,
-  prevId: string | null,
+  prevDelegate: string | null,
   prevTimestamp: string | null,
   controller: string | null
 ) => {
@@ -81,7 +81,7 @@ export const getPaginatedUnstakings = async (
     const params: string[] = [];
 
     let sql = `
-    SELECT "id", "unbondAmount", "borrowAmount" as "offerAmount", "controller", "startTime" as "timestamp", "startBlockHeight"
+    SELECT "delegate", "unbondAmount", "borrowAmount" as "offerAmount", "controller", "startTime" as "timestamp", "startBlockHeight"
     FROM unstake
     WHERE "startBlockHeight" != 0
     `;
@@ -91,18 +91,18 @@ export const getPaginatedUnstakings = async (
       params.push(controller);
     }
 
-    if (prevId) {
-      sql += `AND "id" < $${paramIdx++} `;
-      params.push(prevId);
-    }
-
     if (prevTimestamp) {
       sql += `AND "startTime" < $${paramIdx++} `;
       params.push(prevTimestamp);
     }
 
+    if (prevDelegate) {
+      sql += `AND "delegate" < $${paramIdx++} `;
+      params.push(prevDelegate);
+    }
+
     sql += `
-    ORDER BY "id" DESC, "startTime" DESC
+    ORDER BY "startTime" DESC, "delegate" DESC
     LIMIT $${paramIdx}
     `;
     params.push(`${parsedLimit}`);

--- a/src/routes/api/unstakings/+server.ts
+++ b/src/routes/api/unstakings/+server.ts
@@ -2,15 +2,15 @@ import { getPaginatedUnstakings } from "$lib/db";
 import { json } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
 
-export const GET: RequestHandler = async ({ url, locals, params }) => {
+export const GET: RequestHandler = async ({ url, locals }) => {
   const { db } = locals;
 
   const res = await getPaginatedUnstakings(
     db,
     url.searchParams.get("limit"),
-    url.searchParams.get("prevId"),
+    url.searchParams.get("prevDelegate"),
     url.searchParams.get("prevTimestamp"),
-    params.controller
+    null
   );
 
   if (res.error != null) {

--- a/src/routes/api/unstakings/[controller]/+server.ts
+++ b/src/routes/api/unstakings/[controller]/+server.ts
@@ -8,9 +8,9 @@ export const GET: RequestHandler = async ({ url, locals, params }) => {
   const res = await getPaginatedUnstakings(
     db,
     url.searchParams.get("limit"),
-    url.searchParams.get("prevId"),
+    url.searchParams.get("prevDelegate"),
     url.searchParams.get("prevTimestamp"),
-    null
+    params.controller
   );
 
   if (res.error != null) {


### PR DESCRIPTION
- Update `api/new-unstakings` to `api/unstakings` since endpoint returns all unstakings with an indexed state event.
- Switches the pagination key from `id` to `delegate` since `delegate` is [unique and thus has an index](https://www.postgresql.org/docs/current/indexes-unique.html#:~:text=PostgreSQL%20automatically%20creates%20a%20unique,mechanism%20that%20enforces%20the%20constraint.). `id` is not necessarily ordered in the same way that `timestamp` is since older unstake events can be indexed after newer unstake events. 

New way to query unstaking events:

- `/api/new-unstakings` - Get first page with limit 10
- `/api/new-unstakings?limit=100` - Get first page with limit 100
- `/api/new-unstakings?prevDelegate=kujira1ygftfa08x9cajkegdj78d7luy7c5tgdwsm7se9mxl42x9gk0xktqyv9pt8&prevTimestamp=2024-07-18T16:47:24.146Z` - Get second page with limit 10