### PR TITLE
Display DEX difference decimal numbers as non-zero

### DIFF
--- a/src/lib/analytics/utils.ts
+++ b/src/lib/analytics/utils.ts
@@ -1,3 +1,4 @@
+import type { Balance } from "$lib/wallet/coin";
 import type { IncompleteUnstakeAnalytics, VaultDebts } from "./types";
 import { BigNumber } from "bignumber.js";
 
@@ -59,4 +60,22 @@ export function mapNonNull<S, T>(
   func: (data: S, idx: number) => T | null
 ) {
   return list.map(func).filter((d) => d != null);
+}
+
+export function formatBalance(balance: Balance, decimals: number = 2) {
+  return balance
+    .normalized()
+    .abs()
+    .isLessThan(BigNumber(Math.pow(1, -decimals)))
+    ? balance.humanAmountWithPrecision(1)
+    : balance.humanAmount(decimals);
+}
+
+export function formatBalanceWithUnit(balance: Balance, decimals: number = 3) {
+  return balance
+    .normalized()
+    .abs()
+    .isLessThan(BigNumber(Math.pow(1, -decimals)))
+    ? balance.displayWithPrecision(1)
+    : balance.display(decimals);
 }

--- a/src/lib/analytics/utils.ts
+++ b/src/lib/analytics/utils.ts
@@ -62,11 +62,13 @@ export function mapNonNull<S, T>(
   return list.map(func).filter((d) => d != null);
 }
 
+const BIG_NUMBER_ONE = BigNumber(1.0);
+
 export function formatBalance(balance: Balance, decimals: number = 2) {
   return balance
     .normalized()
     .abs()
-    .isLessThan(BigNumber(Math.pow(1, -decimals)))
+    .isLessThan(BIG_NUMBER_ONE.shiftedBy(-decimals))
     ? balance.humanAmountWithPrecision(1)
     : balance.humanAmount(decimals);
 }
@@ -75,7 +77,7 @@ export function formatBalanceWithUnit(balance: Balance, decimals: number = 3) {
   return balance
     .normalized()
     .abs()
-    .isLessThan(BigNumber(Math.pow(1, -decimals)))
+    .isLessThan(BIG_NUMBER_ONE.shiftedBy(-decimals))
     ? balance.displayWithPrecision(1)
     : balance.display(decimals);
 }

--- a/src/lib/wallet/coin.ts
+++ b/src/lib/wallet/coin.ts
@@ -36,8 +36,16 @@ export class Balance {
     return formatBigNumber(this.normalized(), decimals);
   }
 
+  public humanAmountWithPrecision(precision: number = 2): string {
+    return this.normalized().toPrecision(precision);
+  }
+
   public display(decimals?: number): string {
     return `${this.humanAmount(decimals)} ${this.name}`;
+  }
+
+  public displayWithPrecision(precision?: number): string {
+    return `${this.humanAmountWithPrecision(precision)} ${this.name}`;
   }
 
   public toCoin(): Coin {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,7 @@
   import { browser } from "$app/environment";
   import { goto } from "$app/navigation";
   import { page } from "$app/stores";
+  import { formatBalanceWithUnit } from "$lib/analytics/utils";
   import DenomSelect from "$lib/components/DenomSelect.svelte";
   import NumberInput from "$lib/components/NumberInput.svelte";
   import ReserveMigration from "$lib/components/ReserveMigration.svelte";
@@ -440,7 +441,7 @@
                 <span
                   class="from-red-600 via-red-500 to-amber-500 text-transparent bg-gradient-to-tr bg-clip-text font-bold"
                 >
-                  +{difference.display(3)} (+{differencePct
+                  +{formatBalanceWithUnit(difference)} (+{differencePct
                     .times(100)
                     .toFixed(2)}%)
                 </span>

--- a/src/routes/analytics/+page.svelte
+++ b/src/routes/analytics/+page.svelte
@@ -4,7 +4,7 @@
   import { icon } from "$lib/resources/registry";
   import { getRelativeTime } from "$lib/wallet/utils";
   import { Balance } from "$lib/wallet/coin";
-  import { groupBy } from "$lib/analytics/utils";
+  import { formatBalance, groupBy } from "$lib/analytics/utils";
   import { BigNumber } from "bignumber.js";
   import DateBarChartWrapper from "$lib/graph/DateBarChartWrapper.svelte";
   import DenomSelect from "$lib/components/DenomSelect.svelte";
@@ -27,16 +27,6 @@
     incompleteAnalyticsDataByAsset = incompleteUnstakeAnalytics.filter(
       (d) => d.controller.offer_denom === selectedAsset
     );
-  }
-
-  function formatBalance(balance: Balance) {
-    const normalizedBalance = balance.normalized();
-
-    if (normalizedBalance.abs() < BigNumber(0.01)) {
-      return normalizedBalance.toPrecision(1);
-    }
-
-    return balance.humanAmount(2);
   }
 </script>
 


### PR DESCRIPTION
Ensures that the DEX difference is always displayed as non-zero.

## Before
<img width="1000" alt="Screenshot 2024-07-22 at 8 27 21 PM" src="https://github.com/user-attachments/assets/1de07cfe-b0fc-46c0-b960-e256bac4af65">

If the "Compared to DEX" difference is really small, the number is displayed as 0.

## After
<img width="1023" alt="Screenshot 2024-07-22 at 8 27 32 PM" src="https://github.com/user-attachments/assets/732017af-091a-4076-acf0-34418c78d511">

Regardless of how many digits after the decimal point are used, the difference is always non-zero.